### PR TITLE
Always show the main thread in all-thread ANR traces

### DIFF
--- a/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRError.java
+++ b/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRError.java
@@ -83,6 +83,11 @@ public class ANRError extends Error {
                 )
                 stackTraces.put(entry.getKey(), entry.getValue());
 
+        // Sometimes main is not returned in getAllStackTraces() - ensure that we list it
+        if (!stackTraces.containsKey(mainThread)) {
+            stackTraces.put(mainThread, mainThread.getStackTrace());
+        }
+
         $._Thread tst = null;
         for (Map.Entry<Thread, StackTraceElement[]> entry : stackTraces.entrySet())
             tst = new $(entry.getKey().getName(), entry.getValue()).new _Thread(tst);


### PR DESCRIPTION
I noticed that several of our crash reports from ANR watchdog didn't have an entry for the main thread - it is not being returned in `Thread.getAllStackTraces()` at the point when the watchdog is triggered.

Since we have a reference to the main thread already, then add it to the map if it does not already exist. I now always see the main thread stacktrace at the top of the ANR thread dump.
