### PR TITLE
Show state of each thread in trace

### DIFF
--- a/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRError.java
+++ b/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRError.java
@@ -85,7 +85,7 @@ public class ANRError extends Error {
 
         $._Thread tst = null;
         for (Map.Entry<Thread, StackTraceElement[]> entry : stackTraces.entrySet())
-            tst = new $(entry.getKey().getName(), entry.getValue()).new _Thread(tst);
+            tst = new $(getThreadTitle(entry.getKey()), entry.getValue()).new _Thread(tst);
 
         return new ANRError(tst);
     }
@@ -94,6 +94,10 @@ public class ANRError extends Error {
         final Thread mainThread = Looper.getMainLooper().getThread();
         final StackTraceElement[] mainStackTrace = mainThread.getStackTrace();
 
-        return new ANRError(new $(mainThread.getName(), mainStackTrace).new _Thread(null));
+        return new ANRError(new $(getThreadTitle(mainThread), mainStackTrace).new _Thread(null));
+    }
+
+    private static String getThreadTitle(Thread thread) {
+        return thread.getName() + " (state = " + thread.getState() + ")";
     }
 }


### PR DESCRIPTION
Knowing the state of each thread is really useful in debugging (e.g. determining if we are seeing a deadlock, or just long-running operations on the main thread) - so print out the state of each thread in the trace.

Example output from the test app:

```
07-13 15:48:57.588: E/AndroidRuntime(20144): FATAL EXCEPTION: |ANR-WatchDog|
07-13 15:48:57.588: E/AndroidRuntime(20144): Process: anrwatchdog.github.com.testapp, PID: 20144
07-13 15:48:57.588: E/AndroidRuntime(20144): com.github.anrwatchdog.ANRError: Application Not Responding
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: main (state = TIMED_WAITING)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.sleep(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.sleep(Thread.java:371)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.sleep(Thread.java:313)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.github.anrtestapp.MainActivity.SleepAMinute(MainActivity.java:18)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.github.anrtestapp.MainActivity.access$100(MainActivity.java:12)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.github.anrtestapp.MainActivity$2.onClick(MainActivity.java:63)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.view.View.performClick(View.java:5609)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.view.View$PerformClick.run(View.java:22238)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.os.Handler.handleCallback(Handler.java:751)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.os.Handler.dispatchMessage(Handler.java:95)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.os.Looper.loop(Looper.java:154)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at android.app.ActivityThread.main(ActivityThread.java:6044)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.reflect.Method.invoke(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: FinalizerDaemon (state = WAITING)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Object.wait(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Object.wait(Object.java:407)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:188)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:209)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Daemons$FinalizerDaemon.run(Daemons.java:204)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.run(Thread.java:761)
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: FinalizerWatchdogDaemon (state = WAITING)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Object.wait(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded(Daemons.java:269)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Daemons$FinalizerWatchdogDaemon.run(Daemons.java:249)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	... 1 more
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: HeapTaskDaemon (state = BLOCKED)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at dalvik.system.VMRuntime.runHeapTasks(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Daemons$HeapTaskDaemon.run(Daemons.java:433)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	... 1 more
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: ReferenceQueueDaemon (state = WAITING)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Object.wait(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Daemons$ReferenceQueueDaemon.run(Daemons.java:150)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	... 1 more
07-13 15:48:57.588: E/AndroidRuntime(20144): Caused by: com.github.anrwatchdog.ANRError$$$_Thread: |ANR-WatchDog| (state = RUNNABLE)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at dalvik.system.VMStack.getThreadStackTrace(Native Method)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.getStackTrace(Thread.java:1566)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at java.lang.Thread.getAllStackTraces(Thread.java:1616)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.github.anrwatchdog.ANRError.New(ANRError.java:73)
07-13 15:48:57.588: E/AndroidRuntime(20144): 	at com.github.anrwatchdog.ANRWatchDog.run(ANRWatchDog.java:209)
```