### PR TITLE
add Bugsnag to list of supported crash reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Known working crash reporters include:
 
  * [ACRA](https://github.com/ACRA/acra)
  * [Crashlytics](https://get.fabric.io/crashlytics)
- * [HockeyApp](http://hockeyapp.net/)
+ * [HockeyApp](https://hockeyapp.net/)
+ * [Bugsnag](https://www.bugsnag.com/)
 
 And there is no reason why it should not work with *[insert your favourite crash reporting system here]*.
 


### PR DESCRIPTION
I've performed compatibility testing and have confirmed that it's possible to send an `ANRError` to [Bugsnag](https://www.bugsnag.com) by calling `Bugsnag.notify(error)`. I've added bugsnag to the list of working crash reporters, and also took the liberty of updating hockeyapp to use https rather than http.