### PR TITLE
remove libstatic badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 ANR-WatchDog
 ============
 
-[![Libtastic](http://www.libtastic.com/static/osbadges/54.png)](http://www.libtastic.com/technology/54/)
-
 A simple watchdog that detects Android ANRs (Application Not Responding).
 
 


### PR DESCRIPTION
remove libstatic badge because it's not working anymore and redirect to an adware website