### PR TITLE
Insert ticker runnable using Handler.postAtFrontOfQueue

### DIFF
--- a/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRWatchDog.java
+++ b/anr-watchdog/src/main/java/com/github/anrwatchdog/ANRWatchDog.java
@@ -255,7 +255,7 @@ public class ANRWatchDog extends Thread {
             boolean needPost = _tick == 0;
             _tick += interval;
             if (needPost) {
-                _uiHandler.post(_ticker);
+                _uiHandler.postAtFrontOfQueue(_ticker);
             }
 
             try {


### PR DESCRIPTION
Insert ticker runnable using Handler.postAtFrontOfQueue
instead of Handler.post method, which adds a message to the end of the queue.
This way we detect timeout of the currently running runnable and not the timeout
of the queue of runnables that happens to be in front of the ticker runnable.
    